### PR TITLE
Fix injector races

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "rc-injector"
-version = "0.0.1"
+version = "0.0.2"
 description = "Python dependency injector"
 license = "MIT"
 readme = "README.md"


### PR DESCRIPTION
## Motivation / Description
Ideally the injector is used only once to build the Server class
with all its dependencies. But if used in concurrency we can't
have a shared stack or can lead to races and all short of issues.

## Changes introduced
- Split the context into a class we create for each instantiation
  so we can avoid races between concurrent `injector.get()` calls.
- Add a fast-path for cached instances, so we don't build a context
  object for things already built.